### PR TITLE
[FEAT] Rebuilds cell mappings from scratch

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,52 @@
+/**
+ * @file logger.ts
+ * @description Simple debug logging utility.
+ * 
+ * Logs only appear when: running in development (automatically detected).
+ */
+
+let vscode: typeof import('vscode') | undefined;
+try {
+    vscode = require('vscode');
+} catch {
+    // Running in headless mode (tests)
+}
+
+/**
+ * Check if debug logging is enabled.
+ * Only enabled in VSCode extension development mode.
+ */
+function isDebugEnabled(): boolean {
+    return process.env.__VSCODE_EXTENSION_DEVELOPMENT__ === 'true';
+}
+
+/**
+ * Log a debug message.
+ * Only appears in development.
+ */
+export function debug(...args: any[]): void {
+    if (isDebugEnabled()) {
+        console.log('[MergeNB]', ...args);
+    }
+}
+
+/**
+ * Log an info message (always appears).
+ */
+export function info(...args: any[]): void {
+    console.log('[MergeNB]', ...args);
+}
+
+/**
+ * Log a warning message (always appears).
+ */
+export function warn(...args: any[]): void {
+    console.warn('[MergeNB]', ...args);
+}
+
+/**
+ * Log an error message (always appears).
+ */
+export function error(...args: any[]): void {
+    console.error('[MergeNB]', ...args);
+}

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -18,6 +18,7 @@ import { UnifiedConflictPanel, UnifiedConflict, UnifiedResolution } from './webv
 import { ResolutionChoice, NotebookSemanticConflict, Notebook, NotebookCell, SemanticConflict } from './types';
 import * as gitIntegration from './gitIntegration';
 import { getSettings } from './settings';
+import * as logger from './logger';
 import { promisify } from 'util';
 import { exec as execCallback } from 'child_process';
 
@@ -273,8 +274,8 @@ export class NotebookConflictResolver {
             return;
         }
 
-        console.log('[MergeNB] Applying textual resolutions for:', uri.fsPath);
-        console.log('[MergeNB] Resolutions received:', Array.from(resolution.textualResolutions.entries()).map(([idx, res]) => ({
+        logger.debug('Applying textual resolutions for:', uri.fsPath);
+        logger.debug('Resolutions received:', Array.from(resolution.textualResolutions.entries()).map(([idx, res]) => ({
             index: idx,
             choice: res.choice,
             hasCustomContent: res.customContent !== undefined,
@@ -440,7 +441,7 @@ export class NotebookConflictResolver {
                     } else {
                         cellToAdd.source = customContent;
                     }
-                } else if (customContent !== undefined && !cellToAdd && customContent.trim().length > 0) {
+                } else if (customContent !== undefined && !cellToAdd && customContent.length > 0) {
                     // User added content to a deleted cell - create a new cell
                     // Use the cell type from the non-deleted side, or default to 'code'
                     const referenceCell = localCell || remoteCell || baseCell;
@@ -586,14 +587,14 @@ export class NotebookConflictResolver {
                     }
 
                     // Check if this is a deletion (empty custom content or no cell for chosen side)
-                    if (customContent !== undefined && customContent.trim() === '') {
+                    if (customContent !== undefined && customContent === '') {
                         isDeleted = true;
                     } else if (!cellToUse) {
                         isDeleted = true;
                     }
 
                     // If custom content was provided and not deleted, apply it to the cell
-                    if (customContent !== undefined && customContent.trim() !== '' && cellToUse) {
+                    if (customContent !== undefined && customContent !== '' && cellToUse) {
                         const editedCell: NotebookCell = JSON.parse(JSON.stringify(cellToUse));
                         // Convert source to the same format (string or string[]) as original
                         if (Array.isArray(editedCell.source)) {
@@ -602,7 +603,7 @@ export class NotebookConflictResolver {
                             editedCell.source = customContent;
                         }
                         cellToUse = editedCell;
-                    } else if (customContent !== undefined && customContent.trim() !== '' && !cellToUse) {
+                    } else if (customContent !== undefined && customContent !== '' && !cellToUse) {
                         // User added content to a deleted cell - create a new cell
                         // Use the first available cell as a template for metadata/type
                         const templateCell = localCell || remoteCell || baseCell;

--- a/src/webview/ConflictResolverPanel.ts
+++ b/src/webview/ConflictResolverPanel.ts
@@ -12,6 +12,7 @@
 
 
 import * as vscode from 'vscode';
+import * as logger from '../logger';
 import { 
     NotebookConflict, 
     CellConflict, 
@@ -351,12 +352,12 @@ export class UnifiedConflictPanel {
             return rows;
         }
 
-        console.log('[MergeNB] Building merge rows for textual conflict');
-        console.log('[MergeNB] base cells:', conflict.base?.cells?.length);
-        console.log('[MergeNB] local cells:', conflict.local?.cells?.length);
-        console.log('[MergeNB] remote cells:', conflict.remote?.cells?.length);
-        console.log('[MergeNB] mappings count:', conflict.cellMappings.length);
-        console.log('[MergeNB] original textual conflicts:', conflict.conflicts.length);
+        logger.debug('Building merge rows for textual conflict');
+        logger.debug('base cells:', conflict.base?.cells?.length);
+        logger.debug('local cells:', conflict.local?.cells?.length);
+        logger.debug('remote cells:', conflict.remote?.cells?.length);
+        logger.debug('mappings count:', conflict.cellMappings.length);
+        logger.debug('original textual conflicts:', conflict.conflicts.length);
 
         // For textual conflicts, we detect conflicts by comparing local vs remote
         // from the Git staging areas (not from the working copy markers)
@@ -425,7 +426,7 @@ export class UnifiedConflictPanel {
             });
         }
         
-        console.log('[MergeNB] Detected conflicts from Git comparison:', conflictIndex);
+        logger.debug('Detected conflicts from Git comparison:', conflictIndex);
 
         return rows;
     }
@@ -1819,6 +1820,14 @@ export class UnifiedConflictPanel {
         const resolutions = {};
         const totalConflicts = ${totalConflicts};
         const conflictType = '${conflictType}';
+        const isDebugMode = ${process.env.__VSCODE_EXTENSION_DEVELOPMENT__ === 'true'};
+        
+        // Debug logger - only logs in development mode
+        function debugLog(...args) {
+            if (isDebugMode) {
+                console.log('[MergeNB]', ...args);
+            }
+        }
         
         // Render outputs from JSON data
         function renderOutputsFromData(outputsJson) {
@@ -1963,7 +1972,7 @@ export class UnifiedConflictPanel {
                     resolutions[index].customContent = e.target.value;
                     
                     // Update deleted state based on content (regardless of original state)
-                    const hasContent = e.target.value.trim().length > 0;
+                    const hasContent = e.target.value.length > 0;
                     resolutions[index].isDeleted = !hasContent;
                     
                     // Update the hint text dynamically
@@ -1992,7 +2001,7 @@ export class UnifiedConflictPanel {
             const row = document.querySelector(\`.merge-row[data-conflict="\${index}"]\`);
             if (!row || !resolutions[index]) return;
             
-            console.log('[MergeNB] Applying resolution for conflict', index, ':', {
+            debugLog('Applying resolution for conflict', index, ':', {
                 choice: resolutions[index].choice,
                 isDeleted: resolutions[index].isDeleted,
                 contentLength: resolutions[index].customContent?.length ?? 0,
@@ -2193,7 +2202,7 @@ export class UnifiedConflictPanel {
                 }
             }
             
-            console.log(\`Progress: \${appliedCount}/\${totalConflicts} resolved\`);
+            debugLog(\`Progress: \${appliedCount}/\${totalConflicts} resolved\`);
         }
 
         function applyResolutions() {
@@ -2242,7 +2251,7 @@ export class UnifiedConflictPanel {
                     customContent: data.customContent
                 }));
                 
-                console.log('[MergeNB] Sending resolutions to backend:', resolutionArray.map(r => ({
+                debugLog('Sending resolutions to backend:', resolutionArray.map(r => ({
                     index: r.index,
                     choice: r.choice,
                     contentLength: r.customContent?.length ?? 0,


### PR DESCRIPTION
### Problem:
Previously, we were attempting to **amend** local cells with the correct branch or edit, but this didn't correctly take into account a) indices changing due to addition/removal of cells, nor b) the cell matching process, which could result in duplicates and false matches.


### Solution:

We now iterate through cellMappings in order where each mapping represents one row of cells in the merge view. 

That is, the notebook's metadata is saved, and _rebuilt_ from scratch each time we "apply & save" now.

TODO for a different PR:
- Ordering of cells still needs to be addressed. Our cell matching algorithm needs to be heavily improved here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced notebook merge resolution: builds final notebook from mappings, supports creating previously deleted cells, preserves metadata, and prefers automated resolutions when available.
  * Improved resolution actions: bulk accept/skip already-applied, and consistent handling of deletions.

* **Bug Fixes**
  * More robust handling of missing or empty resolution content and execution-count renumbering propagation.

* **Style/Chores**
  * Added development-mode debug logging to aid diagnostics without affecting production.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->