### PR TITLE
[FEAT] [UI] [Resolver] Drag and drop unmatched cells

### DIFF
--- a/src/webview/ConflictResolverPanel.ts
+++ b/src/webview/ConflictResolverPanel.ts
@@ -301,11 +301,21 @@ export class UnifiedConflictPanel {
                 return posA - posB;
             }
 
-            // Tiebreaker: prefer rows with more matched sides (fully matched before unmatched)
-            const matchedA = (a.baseCell ? 1 : 0) + (a.currentCell ? 1 : 0) + (a.incomingCell ? 1 : 0);
-            const matchedB = (b.baseCell ? 1 : 0) + (b.currentCell ? 1 : 0) + (b.incomingCell ? 1 : 0);
+            // For same anchor position, base-anchored cells should come first
+            // (they represent the "original" cell at that position)
+            const hasBaseA = a.baseCellIndex !== undefined;
+            const hasBaseB = b.baseCellIndex !== undefined;
+            
+            if (hasBaseA !== hasBaseB) {
+                return hasBaseA ? -1 : 1;
+            }
 
-            return matchedB - matchedA; // More matched sides first
+            // Secondary tiebreaker: use the actual cell index on the specific side
+            // This preserves insertion order for cells added in branches
+            const currentPosA = a.currentCellIndex ?? a.incomingCellIndex ?? 0;
+            const currentPosB = b.currentCellIndex ?? b.incomingCellIndex ?? 0;
+
+            return currentPosA - currentPosB;
         });
     }
 


### PR DESCRIPTION
- Order by idx such that unmatched cells do not go all the way at the bottom, and provide some clues as to where to place them.

- Mark unmatched cells with a yellow highlight + hue.

- Fixes issues with cells getting deleted because they were matched to a previously set-to-delete spot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop functionality for unmatched cells to enable flexible cell repositioning.
  * Visual indicators now clearly distinguish unmatched and deleted cells in merge conflict views.

* **Bug Fixes**
  * Improved consistency in cell ordering to ensure predictable cell arrangement across base, current, and incoming versions.
  * Enhanced conflict resolution with better handling of deleted cells and custom content integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->