### PR TITLE
[FIX] Metadata Holes

### DIFF
--- a/src/web/client/ConflictResolver.tsx
+++ b/src/web/client/ConflictResolver.tsx
@@ -82,7 +82,7 @@ export function ConflictResolver({
     onCancel,
 }: ConflictResolverProps): React.ReactElement {
     const initialRows = conflict.type === 'semantic' && conflict.semanticConflict
-        ? buildMergeRowsFromSemantic(conflict.semanticConflict)
+        ? buildMergeRowsFromSemantic(conflict.semanticConflict, conflict.autoResolveResult?.resolvedNotebook)
         : [];
 
     const [choices, setChoices] = useState<Map<number, ResolutionState>>(new Map());
@@ -826,7 +826,10 @@ export function ConflictResolver({
 /**
  * Build merge rows from semantic conflict data.
  */
-function buildMergeRowsFromSemantic(conflict: NotebookSemanticConflict): MergeRowType[] {
+function buildMergeRowsFromSemantic(
+    conflict: NotebookSemanticConflict,
+    currentNotebookOverride?: import('../../types').Notebook
+): MergeRowType[] {
     const rows: MergeRowType[] = [];
     const conflictMap = new Map<string, { conflict: SemanticConflict; index: number }>();
 
@@ -838,8 +841,9 @@ function buildMergeRowsFromSemantic(conflict: NotebookSemanticConflict): MergeRo
     for (const mapping of conflict.cellMappings) {
         const baseCell = mapping.baseIndex !== undefined && conflict.base
             ? conflict.base.cells[mapping.baseIndex] : undefined;
-        const currentCell = mapping.currentIndex !== undefined && conflict.current
-            ? conflict.current.cells[mapping.currentIndex] : undefined;
+        const currentSource = currentNotebookOverride || conflict.current;
+        const currentCell = mapping.currentIndex !== undefined && currentSource
+            ? currentSource.cells[mapping.currentIndex] : undefined;
         const incomingCell = mapping.incomingIndex !== undefined && conflict.incoming
             ? conflict.incoming.cells[mapping.incomingIndex] : undefined;
 


### PR DESCRIPTION
Fixes:
- Notebook top-level metadata is always taken from current (unless auto-resolve produced a replacement). Incoming-only notebook metadata changes can be silently lost even if you “Use Incoming” per-cell. This is in the reconstruction path in resolver.ts.
- “Cell added in both” only compares source; if both sides add same source but differ in metadata/outputs, it’s treated as non-conflict and will deterministically pick current (potentially dropping incoming metadata/outputs). This is in conflictDetector.ts.
- Conflict detection uses JSON.stringify() for metadata/outputs comparison; key-order differences can create false positives/negatives. Switching to a stable stringify would reduce noise.

closes #39 #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings-aware conflict detection and auto-resolution for execution counts, outputs, and kernel versions.
  * Improved metadata conflict detection and merging across notebook versions.

* **Bug Fixes**
  * Enhanced deterministic comparisons for outputs, metadata, and kernel information to ensure consistent conflict detection.
  * UI now accurately reflects auto-resolved notebook changes.

* **Tests**
  * Added regression test for metadata-changed conflicts in cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->