### PR TITLE
[CI] Bump Node to 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version used in release operations for improved stability and performance in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->