### PR TITLE
Add all packages to dependabot and add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 21
     commit-message:
       prefix: "[chore]"
       include: "scope"
@@ -65,5 +67,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 21
     commit-message:
       prefix: "[CI]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,16 +17,40 @@ updates:
     groups:
       dev-dependencies:
         patterns:
+          - "@clack/prompts"
+          - "@playwright/test"
           - "@types/*"
           - "@typescript-eslint/*"
+          - "@vscode/test-electron"
+          - "@vscode/vsce"
+          - "esbuild"
           - "eslint*"
+          - "npm-run-all"
+          - "picocolors"
+          - "react"
+          - "react-dom"
           - "typescript"
+          - "typescript-eslint"
+          - "knip"
         update-types:
           - "minor"
           - "patch"
       production-dependencies:
         patterns:
-          - "*"
+          - "@codemirror/language"
+          - "@codemirror/language-data"
+          - "@codemirror/merge"
+          - "@jupyterlab/rendermime"
+          - "@tanstack/react-virtual"
+          - "@uiw/codemirror-theme-github"
+          - "@uiw/react-codemirror"
+          - "@vscode/markdown-it-katex"
+          - "dompurify"
+          - "immer"
+          - "katex"
+          - "markdown-it"
+          - "ws"
+          - "zustand"
         exclude-patterns:
           - "@types/*"
           - "@typescript-eslint/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,57 +11,20 @@ updates:
     cooldown:
       default-days: 21
     commit-message:
-      prefix: "[chore]"
+      prefix: "chore"
       include: "scope"
     pull-request-branch-name:
       separator: "/"
     # Group minor and patch updates together
     groups:
       dev-dependencies:
+        dependency-type: "development"
         patterns:
-          - "@clack/prompts"
-          - "@playwright/test"
-          - "@types/*"
-          - "@typescript-eslint/*"
-          - "@vscode/test-electron"
-          - "@vscode/vsce"
-          - "esbuild"
-          - "eslint*"
-          - "npm-run-all"
-          - "picocolors"
-          - "react"
-          - "react-dom"
-          - "typescript"
-          - "typescript-eslint"
-          - "knip"
-        update-types:
-          - "minor"
-          - "patch"
+          - "*"
       production-dependencies:
+        dependency-type: "production"
         patterns:
-          - "@codemirror/language"
-          - "@codemirror/language-data"
-          - "@codemirror/merge"
-          - "@jupyterlab/rendermime"
-          - "@tanstack/react-virtual"
-          - "@uiw/codemirror-theme-github"
-          - "@uiw/react-codemirror"
-          - "@vscode/markdown-it-katex"
-          - "dompurify"
-          - "immer"
-          - "katex"
-          - "markdown-it"
-          - "ws"
-          - "zustand"
-        exclude-patterns:
-          - "@types/*"
-          - "@typescript-eslint/*"
-          - "eslint*"
-          - "typescript"
-        update-types:
-          - "minor"
-          - "patch"
-
+          - "*"
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -70,4 +33,4 @@ updates:
     cooldown:
       default-days: 21
     commit-message:
-      prefix: "[CI]"
+      prefix: "ci"


### PR DESCRIPTION
# Motivation

I was under the impression that dependabot already tracked all packages automatically, for some reason.

# Solution

- Add all packages as a permissive "*" allowlist to dependabot config
- Add a cooldown period (dependabot doesn't open a PR until 21 days after update)  on all pcakages to prevent most supply chain attacks (https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management: added a 21-day cooldown between update PRs, standardized commit-message prefixes to lowercase, and reworked grouping rules to broadly separate development vs production dependencies and simplify which packages are targeted for updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->