### PR TITLE
fix(ci): release and packaging process for monorepo structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Update package-lock.json
         run: npm install --package-lock-only
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run compile
+
       - name: Generate changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm ci
 
       - name: Build extension
-        run: npm run compile
+        run: npm run package
 
       - name: Generate changelog
         env:

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,16 +1,30 @@
-test/**
-src/tests/**
-src/**
+# Source files - only dist/ is needed
+apps/**
+packages/**
 out/**
+
+# Test files and fixtures
+test-fixtures/**
+apps/vscode-extension/tests/**
+playwright-report/**
+playwright-test-results/**
+
+# Build/dev files
 .github/**
 .vscode/**
-readme-assets/**
-node_modules/**
+.claude/**
 esbuild.js
 eslint.config.mjs
 tsconfig.json
 playwright.config.ts
+knip.json
+
+# Config files
 .gitignore
 .vscodeignore
 output.txt
 AGENTS.md
+readme-assets/**
+
+# Dependencies (vsce excludes by default, but explicit for clarity)
+node_modules/**


### PR DESCRIPTION
## Motivation:
Activation events weren't firing at all after using the .vsix from release 0.1.1. After looking deeper into the github releases, I found that 0.1.1 and 0.1.0 (which used the release.yml script) had .vsix of ~2 mb, and  all earlier releases had ~12mb. 

## Solution:
The problem turned out to be that I didn't add "npm ci"(install deps) + "npm run compile"(compile) and it was literally somehow just packaging source code (AFAIK).

I added those two commands into the release script, as well as updated the .vscodeignore to reflect the new monorepo structure 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now runs an extra dependency install step and a package build phase before changelog generation to improve build verification.
  * Refined editor/package ignore patterns to exclude unnecessary dev/test artifacts while preserving compiled output and essential assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->