### PR TITLE
Fixes innaccurate, noisy diffs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@uiw/codemirror-theme-github": "^4.25.9",
         "@uiw/react-codemirror": "^4.25.9",
         "@vscode/markdown-it-katex": "^1.1.2",
+        "diff": "^9.0.0",
         "dompurify": "^3.3.3",
         "immer": "^11.1.4",
         "katex": "^0.16.44",
@@ -5024,6 +5025,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-serializer": {

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@uiw/codemirror-theme-github": "^4.25.9",
     "@uiw/react-codemirror": "^4.25.9",
     "@vscode/markdown-it-katex": "^1.1.2",
+    "diff": "^9.0.0",
     "dompurify": "^3.3.3",
     "immer": "^11.1.4",
     "katex": "^0.16.44",

--- a/packages/core/src/diffMarks.ts
+++ b/packages/core/src/diffMarks.ts
@@ -1,0 +1,124 @@
+/**
+ * @file diffMarks.ts
+ * @description Compute line-level and inline word-level diff marks for two
+ * versions of a cell source, independent of any rendering layer.
+ *
+ * Strategy (industry-standard two-pass diff):
+ *   1. `diffLines` to find which lines were added/removed — drives line
+ *      background classes.
+ *   2. `diffWordsWithSpace` between paired removed/added line hunks — drives
+ *      inline highlight ranges. Word-level (not character-level) avoids the
+ *      noisy single-character matching that a raw string diff produces.
+ *
+ * `diffWordsWithSpace` is preferred over `diffWords` so whitespace-only
+ * changes survive into the result (the caller treats them as conflicts).
+ */
+
+import { diffLines, diffWordsWithSpace } from 'diff';
+
+export type DiffSide = 'base' | 'current' | 'incoming';
+export type DiffMode = 'base' | 'conflict';
+
+export interface InlineDiffRange {
+    from: number;
+    to: number;
+    classes: string;
+}
+
+export interface DiffMarks {
+    /** Map from 0-based line index in `source` to a CSS class string. */
+    lineClasses: Map<number, string>;
+    /** Absolute character ranges in `source` for inline highlights. */
+    inlineRanges: InlineDiffRange[];
+}
+
+interface SideClasses {
+    lineClass: string;
+    inlineClass: string;
+}
+
+const CONFLICT_CLASSES: SideClasses = {
+    lineClass: 'diff-line diff-line-conflict',
+    inlineClass: 'diff-inline-conflict',
+};
+
+const SIDE_CLASSES: Record<DiffSide, SideClasses> = {
+    base: { lineClass: 'diff-line diff-line-base', inlineClass: 'diff-inline-base' },
+    current: { lineClass: 'diff-line diff-line-current', inlineClass: 'diff-inline-current' },
+    incoming: { lineClass: 'diff-line diff-line-incoming', inlineClass: 'diff-inline-incoming' },
+};
+
+export function computeDiffMarks(
+    source: string,
+    compareSource: string,
+    side: DiffSide,
+    diffMode: DiffMode,
+): DiffMarks {
+    const lineClasses = new Map<number, string>();
+    const inlineRanges: InlineDiffRange[] = [];
+
+    const sideClasses = SIDE_CLASSES[side];
+    const lineOfPos = makeLineOfPos(source);
+
+    const hunks = diffLines(compareSource, source);
+
+    let bOffset = 0;
+    let pendingRemoved = '';
+
+    for (const hunk of hunks) {
+        if (hunk.removed) {
+            pendingRemoved += hunk.value;
+            continue;
+        }
+
+        if (hunk.added) {
+            const hunkStart = bOffset;
+            const hunkEnd = bOffset + hunk.value.length;
+
+            const isWhitespaceOnly = hunk.value.length > 0 && hunk.value.trim() === '';
+            const useConflict = diffMode === 'conflict' || isWhitespaceOnly;
+            const { lineClass, inlineClass } = useConflict ? CONFLICT_CLASSES : sideClasses;
+
+            const firstLine = lineOfPos(hunkStart);
+            const lastLine = lineOfPos(Math.max(hunkStart, hunkEnd - 1));
+            for (let ln = firstLine; ln <= lastLine; ln++) lineClasses.set(ln, lineClass);
+
+            if (pendingRemoved.length > 0) {
+                let cursor = hunkStart;
+                for (const wc of diffWordsWithSpace(pendingRemoved, hunk.value)) {
+                    if (wc.removed) continue;
+                    if (wc.added) {
+                        inlineRanges.push({ from: cursor, to: cursor + wc.value.length, classes: inlineClass });
+                    }
+                    cursor += wc.value.length;
+                }
+            } else {
+                inlineRanges.push({ from: hunkStart, to: hunkEnd, classes: inlineClass });
+            }
+
+            pendingRemoved = '';
+            bOffset = hunkEnd;
+            continue;
+        }
+
+        pendingRemoved = '';
+        bOffset += hunk.value.length;
+    }
+
+    return { lineClasses, inlineRanges };
+}
+
+function makeLineOfPos(source: string): (pos: number) => number {
+    const lineStarts: number[] = [0];
+    for (let i = 0; i < source.length; i++) {
+        if (source[i] === '\n') lineStarts.push(i + 1);
+    }
+    return (pos: number): number => {
+        let lo = 0, hi = lineStarts.length - 1;
+        while (lo < hi) {
+            const mid = (lo + hi + 1) >> 1;
+            if (lineStarts[mid] <= pos) lo = mid; else hi = mid - 1;
+        }
+        return lo;
+    };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@ export * from './cellMatcher';
 
 export * from './conflictDetector';
 
+export * from './diffMarks';
+
 export * from './logger';
 
 export * from './notebookParser';

--- a/packages/web/client/src/components/CellContent.tsx
+++ b/packages/web/client/src/components/CellContent.tsx
@@ -15,8 +15,7 @@ import { IRenderMime, OutputModel, RenderMimeRegistry, standardRendererFactories
 import { Widget } from '@lumino/widgets';
 import DOMPurify from 'dompurify';
 import type { NotebookCell, CellOutput } from '../types';
-import { normalizeCellSource } from '../../../../core/src';
-import { diff as computeDiff } from '@codemirror/merge';
+import { computeDiffMarks, normalizeCellSource } from '../../../../core/src';
 import * as logger from '../../../../core/src';
 import type { Highlighter } from '@lezer/highlight';
 import { highlightCode } from '@lezer/highlight';
@@ -77,69 +76,6 @@ function getSyntaxTokens(
         logger.debug('[MergeNB] Failed to parse syntax tree for highlighting:', err);
         return tokens;
     }
-}
-
-/** Compute diff line- and inline-level marks (standalone, no CodeMirror state). */
-function computeDiffMarks(
-    source: string,
-    compareSource: string,
-    side: 'base' | 'current' | 'incoming',
-    diffMode: 'base' | 'conflict',
-): { lineClasses: Map<number, string>; inlineRanges: { from: number; to: number; classes: string }[] } {
-    const lineClasses = new Map<number, string>();
-    const inlineRanges: { from: number; to: number; classes: string }[] = [];
-    const changes = computeDiff(compareSource, source);
-
-    // Build line-start lookup (0-based line indices)
-    const lineStarts: number[] = [0];
-    for (let i = 0; i < source.length; i++) {
-        if (source[i] === '\n') lineStarts.push(i + 1);
-    }
-    const lineOfPos = (pos: number): number => {
-        let lo = 0, hi = lineStarts.length - 1;
-        while (lo < hi) {
-            const mid = (lo + hi + 1) >> 1;
-            if (lineStarts[mid] <= pos) lo = mid; else hi = mid - 1;
-        }
-        return lo;
-    };
-
-    for (const change of changes) {
-        if (change.fromB === change.toB) continue;
-
-        const changedText = source.slice(change.fromB, change.toB);
-        const isWhitespaceOnly = changedText.length > 0 && changedText.trim() === '';
-        const useConflictClass = diffMode === 'conflict' || isWhitespaceOnly;
-
-        const lineClass = useConflictClass
-            ? 'diff-line diff-line-conflict'
-            : side === 'current'
-                ? 'diff-line diff-line-current'
-                : side === 'base'
-                    ? 'diff-line diff-line-base'
-                    : 'diff-line diff-line-incoming';
-        const inlineClass = useConflictClass
-            ? 'diff-inline-conflict'
-            : side === 'current'
-                ? 'diff-inline-current'
-                : side === 'base'
-                    ? 'diff-inline-base'
-                    : 'diff-inline-incoming';
-
-        const firstLine = lineOfPos(change.fromB);
-        const lastLine = lineOfPos(Math.max(change.fromB, change.toB - 1));
-        for (let ln = firstLine; ln <= lastLine; ln++) lineClasses.set(ln, lineClass);
-
-        const aSlice = compareSource.slice(change.fromA, change.toA);
-        const bSlice = source.slice(change.fromB, change.toB);
-        for (const sub of computeDiff(aSlice, bSlice)) {
-            if (sub.fromB < sub.toB) {
-                inlineRanges.push({ from: change.fromB + sub.fromB, to: change.fromB + sub.toB, classes: inlineClass });
-            }
-        }
-    }
-
-    return { lineClasses, inlineRanges };
 }
 
 interface StaticSegment {


### PR DESCRIPTION
## Before:

<img width="1866" height="332" alt="Screenshot From 2026-04-29 10-36-44" src="https://github.com/user-attachments/assets/ddf9e16b-7cca-4914-88f9-b1317f51f9ff" />

## After:
<img width="1929" height="378" alt="Screenshot From 2026-04-29 10-32-45" src="https://github.com/user-attachments/assets/bdffb330-ba9d-4358-b276-952a944f80cc" />

## Motivation:
Previously, we were (a) diffing twice, (b) producing character-level, instead of word-level diffs. This uses the standard `diff` package for a 2-pass line, then word, level diff.

## Side-benefits:
- Refactors diff logic into `packages/core` instead of `packages/web`