### PR TITLE
chore(client): add tooltips to confusing buttons

### DIFF
--- a/packages/web/client/src/components/ConflictResolver.tsx
+++ b/packages/web/client/src/components/ConflictResolver.tsx
@@ -624,6 +624,7 @@ export function ConflictResolver({
                             </button>
                             <div className="history-menu" ref={historyMenuRef}>
                                 <button
+                                    title="View and jump to previous resolution states"
                                     className="btn btn-secondary history-toggle"
                                     onClick={() => setHistoryOpen(prev => !prev)}
                                     aria-expanded={historyOpen}
@@ -706,7 +707,7 @@ export function ConflictResolver({
                                         fontSize: 11,
                                         padding: '4px 8px'
                                     }}
-                                    title="Accept all base (original) changes"
+                                    title="Accept all base changes for remaining conflicts"
                                     onMouseDown={e => mouseDownGuardActiveEditing(e, () => handleAcceptAll('base'))}
                                     onClick={() => {
                                         if (suppressGuardedClickRef.current) { suppressGuardedClickRef.current = false; return; }
@@ -725,7 +726,7 @@ export function ConflictResolver({
                                     fontSize: 11,
                                     padding: '4px 8px',
                                 }}
-                                title="Accept all current (local) changes"
+                                title="Accept all current changes for remaining conflicts"
                                 onMouseDown={e => mouseDownGuardActiveEditing(e, () => handleAcceptAll('current'))}
                                 onClick={() => {
                                     if (suppressGuardedClickRef.current) { suppressGuardedClickRef.current = false; return; }
@@ -743,7 +744,7 @@ export function ConflictResolver({
                                     fontSize: 11,
                                     padding: '4px 8px'
                                 }}
-                                title="Accept all incoming (remote) changes"
+                                title="Accept all incoming changes for remaining conflicts"
                                 onMouseDown={e => mouseDownGuardActiveEditing(e, () => handleAcceptAll('incoming'))}
                                 onClick={() => {
                                     if (suppressGuardedClickRef.current) { suppressGuardedClickRef.current = false; return; }
@@ -770,6 +771,9 @@ export function ConflictResolver({
                             Mark as resolved (stage in Git)
                         </label>
                         <button
+                            title={allResolved ?
+                                "Write the merged notebook with your resolution choices"
+                                : "Resolve all conflicts before applying"}
                             className="btn btn-primary"
                             onMouseDown={handleResolveMouseDown}
                             onClick={handleResolve}

--- a/packages/web/client/src/components/MergeRow.tsx
+++ b/packages/web/client/src/components/MergeRow.tsx
@@ -530,7 +530,10 @@ function MergeRowInner({
                                 showCellHeaders={showCellHeaders}
                             />
                         ) : (
-                            <div className="cell-placeholder cell-deleted">
+                            <div
+                                className="cell-placeholder cell-deleted"
+                                title={row.isUnmatched ? "This branch has no cell here — the cell exists only in the other column(s)" : undefined}
+                            >
                                 <span className="placeholder-text">{getPlaceholderText('base')}</span>
                             </div>
                         )}
@@ -551,7 +554,10 @@ function MergeRowInner({
                             showCellHeaders={showCellHeaders}
                         />
                     ) : (
-                        <div className="cell-placeholder cell-deleted">
+                        <div
+                            className="cell-placeholder cell-deleted"
+                            title={row.isUnmatched ? "This branch has no cell here — the cell exists only in the other column(s)" : undefined}
+                        >
                             <span className="placeholder-text">{getPlaceholderText('current')}</span>
                         </div>
                     )}
@@ -571,7 +577,10 @@ function MergeRowInner({
                             showCellHeaders={showCellHeaders}
                         />
                     ) : (
-                        <div className="cell-placeholder cell-deleted">
+                        <div
+                            className="cell-placeholder cell-deleted"
+                            title={row.isUnmatched ? "This branch has no cell here — the cell exists only in the other column(s)" : undefined}
+                        >
                             <span className="placeholder-text">{getPlaceholderText('incoming')}</span>
                         </div>
                     )}

--- a/packages/web/client/src/components/MergeRow.tsx
+++ b/packages/web/client/src/components/MergeRow.tsx
@@ -471,6 +471,7 @@ function MergeRowInner({
                 </div>
                 <div className="conflict-action-right">
                     <button
+                        title="Resolve by omitting this cell from the merged notebook"
                         className={`btn-resolve btn-delete ${resolutionState?.choice === 'delete' ? 'selected' : ''}`}
                         onClick={() => handleChoiceClick('delete')}
                     >


### PR DESCRIPTION
## Motivation

Clarify various non-obvious `conflict-resolver`/`merge-row` button actions

- added: delete, history, apply resolution
- edited: take all base/cur/incoming to make it clear we respect resolved changes

closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to conflict resolution controls, including the History toggle button, accept-all options, and the Apply Resolution button for enhanced clarity during merge operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Avni2000/MergeNB/pull/255)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->