### PR TITLE
Next Conflict Button

### DIFF
--- a/packages/web/client/src/components/ConflictResolver.tsx
+++ b/packages/web/client/src/components/ConflictResolver.tsx
@@ -232,8 +232,8 @@ export function ConflictResolver({
         const allConflictEls = Array.from(
             container.querySelectorAll<HTMLElement>('[data-testid^="conflict-row-"]')
         ).filter(el => {
-            const idx = Number.parseInt((el.dataset.testid ?? '').replace('conflict-row-', ''), 10);
-            return !Number.isNaN(idx) && !choices.has(idx);
+            const idx = parseInt((el.getAttribute('data-testid') ?? '').replace('conflict-row-', ''), 10);
+            return !isNaN(idx) && !choices.has(idx);
         });
 
         if (allConflictEls.length === 0) return;
@@ -248,7 +248,7 @@ export function ConflictResolver({
 
         const nextIdx = (currentIdx + 1) % allConflictEls.length;
         allConflictEls[nextIdx].scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, [choices, mainContentRef]);
+    }, [choices]);
     const canUndo = history.index > 0;
     const canRedo = history.index < history.entries.length - 1;
     const enableUndoRedoHotkeys = conflict.enableUndoRedoHotkeys ?? true;

--- a/packages/web/client/src/components/ConflictResolver.tsx
+++ b/packages/web/client/src/components/ConflictResolver.tsx
@@ -232,8 +232,8 @@ export function ConflictResolver({
         const allConflictEls = Array.from(
             container.querySelectorAll<HTMLElement>('[data-testid^="conflict-row-"]')
         ).filter(el => {
-            const idx = parseInt((el.getAttribute('data-testid') ?? '').replace('conflict-row-', ''), 10);
-            return !isNaN(idx) && !choices.has(idx);
+            const idx = Number.parseInt((el.dataset.testid ?? '').replace('conflict-row-', ''), 10);
+            return !Number.isNaN(idx) && !choices.has(idx);
         });
 
         if (allConflictEls.length === 0) return;

--- a/packages/web/client/src/components/ConflictResolver.tsx
+++ b/packages/web/client/src/components/ConflictResolver.tsx
@@ -223,6 +223,32 @@ export function ConflictResolver({
     const totalConflicts = conflictRows.length;
     const resolvedCount = choices.size;
     const allResolved = resolvedCount === totalConflicts;
+    const unresolvedCount = totalConflicts - resolvedCount;
+
+    const handleNextConflict = useCallback(() => {
+        const container = mainContentRef.current;
+        if (!container) return;
+
+        const allConflictEls = Array.from(
+            container.querySelectorAll<HTMLElement>('[data-testid^="conflict-row-"]')
+        ).filter(el => {
+            const idx = parseInt((el.getAttribute('data-testid') ?? '').replace('conflict-row-', ''), 10);
+            return !isNaN(idx) && !choices.has(idx);
+        });
+
+        if (allConflictEls.length === 0) return;
+
+        const containerTop = container.getBoundingClientRect().top;
+        let currentIdx = -1;
+        for (let i = 0; i < allConflictEls.length; i++) {
+            if (allConflictEls[i].getBoundingClientRect().top - containerTop <= 40) {
+                currentIdx = i;
+            }
+        }
+
+        const nextIdx = (currentIdx + 1) % allConflictEls.length;
+        allConflictEls[nextIdx].scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, [choices, mainContentRef]);
     const canUndo = history.index > 0;
     const canRedo = history.index < history.entries.length - 1;
     const enableUndoRedoHotkeys = conflict.enableUndoRedoHotkeys ?? true;
@@ -423,6 +449,14 @@ export function ConflictResolver({
                         <span className="conflict-counter">
                             {resolvedCount} / {totalConflicts} resolved
                         </span>
+                        <button
+                            className="btn btn-secondary"
+                            onClick={handleNextConflict}
+                            disabled={unresolvedCount === 0}
+                            title={unresolvedCount === 0 ? 'All conflicts resolved' : 'Scroll to next unresolved conflict'}
+                        >
+                            Next Conflict &#8595;
+                        </button>
                         <div className="header-group">
                                 <button
                                     className="btn btn-secondary"

--- a/packages/web/client/src/styles.ts
+++ b/packages/web/client/src/styles.ts
@@ -254,6 +254,7 @@ ${bodySel} {
     display: flex;
     align-items: center;
     gap: 12px;
+    flex-wrap: wrap;
 }
 
 .header-group {


### PR DESCRIPTION
# Motivation
If you have a very large notebook, it'd be nice to quick scroll to the "next" (wraps around) unresolved conflict.

# Fix
Creates said functionality, with a small fix that gives special attention to the navbar overflowing; we'd like to be able to support small width screens/windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Next Conflict ↓" button to navigate through unresolved conflicts with smooth scrolling; button disables when all conflicts are resolved

* **Style**
  * Enhanced header layout flexibility for improved responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->