### PR TITLE
fix: Deps within `apps/website/package.json` aren't updated by dependabot and should be pinned to the same version as root

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -15,32 +15,20 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@codemirror/language": "^6.12.4",
-    "@codemirror/language-data": "^6.5.2",
-    "@codemirror/merge": "^6.12.2",
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
     "@docusaurus/core": "3.10.1",
     "@docusaurus/faster": "^3.10.2",
     "@docusaurus/preset-classic": "3.10.1",
-    "@jupyterlab/rendermime": "^4.6.0",
     "@lezer/highlight": "^1.2.3",
     "@lumino/widgets": "^2.7.5",
     "@mdx-js/react": "^3.0.0",
-    "@uiw/codemirror-theme-github": "^4.25.10",
-    "@uiw/react-codemirror": "^4.25.10",
-    "@vscode/markdown-it-katex": "^1.1.2",
     "clsx": "^2.0.0",
-    "diff": "^9.0.0",
     "docusaurus-plugin-image-zoom": "^3.0.1",
-    "dompurify": "^3.4.11",
-    "immer": "^11.1.8",
-    "markdown-it": "^14.2.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "style-mod": "^4.1.3",
-    "zustand": "^5.0.14"
+    "style-mod": "^4.1.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",


### PR DESCRIPTION
Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated website dependencies by removing several unused editor, notebook, Markdown, diffing, and state-management packages.
  * Added support for improved style handling through a new styling dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->